### PR TITLE
Add libtommath Git-build

### DIFF
--- a/profile/libtommath.json
+++ b/profile/libtommath.json
@@ -2,6 +2,7 @@
   "Name":           "libtommath",
   "Title":          "LibTomMath",
   "SourceUrl":      "https://github.com/libtom/libtommath/tags",
+  "Git":            "https://github.com/libtom/libtommath.git",
   "Maintainer":     "Andrey P.",
   "MaintainerUrl":  "http://abi-laboratory.pro/",
   "BuildScript":    "build_script/libtommath.sh",


### PR DESCRIPTION
I'm not sure if that's the correct approach, but that's the only major difference between this config and the one of libtomcrypt I've found, and ltc has the build of the latest version included.