### PR TITLE
build_script: fix efl build script to work without sudo

### DIFF
--- a/build_script/efl.sh
+++ b/build_script/efl.sh
@@ -1,3 +1,5 @@
+sed -i -e "s/subdir(join_paths('dbus-services'))//g" meson.build
+sed -i -e "s/subdir(join_paths('systemd-services'))//g" meson.build
 meson -Dphysics=true -Davahi=true --buildtype debug . build_dir --prefix="$INSTALL_TO"
 cd build_dir
 sed -i -e "s/ -g / -g -Og -w -fpermissive /g" build.ninja


### PR DESCRIPTION
The ethumb dbus and systemd service files are installed outside the
given prefix and meson tries to install them in the normal location,
asking for higher privileges during install.
Disable these parts for this build. They are only needed during runtime
anyway.